### PR TITLE
fix: get_slip_days_for_run.js

### DIFF
--- a/conductor/get_slip_days_for_run.js
+++ b/conductor/get_slip_days_for_run.js
@@ -21,9 +21,9 @@ if (process.argv.length != 3) {
                 process.exit(1);
             }
 
-            var assignment_deadline = rows[0].deadline;
-            var slip_days_used = score.calc_slip_days_for(run_timestamp,
-                assignment_deadline);
+            var assignment = rows[0];
+            var slip_days_used = score.calc_slip_days_for(run_timestamp, assignment);
+
             console.log(slip_days_used + " slip day(s) used.");
             process.exit(0);
         });


### PR DESCRIPTION
The second argument for score.calc_slip_days_for should be assignment (the assignment object should have deadline and costs_slip_days as fields).